### PR TITLE
Update resource links from HTTP to HTTPS

### DIFF
--- a/404.html
+++ b/404.html
@@ -38,13 +38,13 @@
     
     <link rel="canonical" href="http://diogo-cruz.github.io/404.html" />
 
-    <link rel="stylesheet" type="text/css" href="http://diogo-cruz.github.io//css/normalize.min.css" media="print" onload="this.media='all'">
-    <link rel="stylesheet" type="text/css" href="http://diogo-cruz.github.io//css/main.css">
-    <link disabled id="dark-theme" rel="stylesheet" href="http://diogo-cruz.github.io//css/dark.css">
+    <link rel="stylesheet" type="text/css" href="https://diogo-cruz.github.io//css/normalize.min.css" media="print" onload="this.media='all'">
+    <link rel="stylesheet" type="text/css" href="https://diogo-cruz.github.io//css/main.css">
+    <link disabled id="dark-theme" rel="stylesheet" href="https://diogo-cruz.github.io//css/dark.css">
 
-    <script src="http://diogo-cruz.github.io//js/svg-injector.min.js"></script>
-    <script src="http://diogo-cruz.github.io//js/feather-icons.min.js"></script>
-    <script src="http://diogo-cruz.github.io//js/main.js"></script>
+    <script src="https://diogo-cruz.github.io//js/svg-injector.min.js"></script>
+    <script src="https://diogo-cruz.github.io//js/feather-icons.min.js"></script>
+    <script src="https://diogo-cruz.github.io//js/main.js"></script>
 
     
     

--- a/categories/index.html
+++ b/categories/index.html
@@ -38,13 +38,13 @@
     
     <link rel="canonical" href="http://diogo-cruz.github.io/categories/" />
 
-    <link rel="stylesheet" type="text/css" href="http://diogo-cruz.github.io//css/normalize.min.css" media="print" onload="this.media='all'">
-    <link rel="stylesheet" type="text/css" href="http://diogo-cruz.github.io//css/main.css">
-    <link disabled id="dark-theme" rel="stylesheet" href="http://diogo-cruz.github.io//css/dark.css">
+    <link rel="stylesheet" type="text/css" href="https://diogo-cruz.github.io//css/normalize.min.css" media="print" onload="this.media='all'">
+    <link rel="stylesheet" type="text/css" href="https://diogo-cruz.github.io//css/main.css">
+    <link disabled id="dark-theme" rel="stylesheet" href="https://diogo-cruz.github.io//css/dark.css">
 
-    <script src="http://diogo-cruz.github.io//js/svg-injector.min.js"></script>
-    <script src="http://diogo-cruz.github.io//js/feather-icons.min.js"></script>
-    <script src="http://diogo-cruz.github.io//js/main.js"></script>
+    <script src="https://diogo-cruz.github.io//js/svg-injector.min.js"></script>
+    <script src="https://diogo-cruz.github.io//js/feather-icons.min.js"></script>
+    <script src="https://diogo-cruz.github.io//js/main.js"></script>
 
     
     

--- a/index.html
+++ b/index.html
@@ -39,13 +39,13 @@
     
     <link rel="canonical" href="http://diogo-cruz.github.io/" />
 
-    <link rel="stylesheet" type="text/css" href="http://diogo-cruz.github.io//css/normalize.min.css" media="print" onload="this.media='all'">
-    <link rel="stylesheet" type="text/css" href="http://diogo-cruz.github.io//css/main.css">
-    <link disabled id="dark-theme" rel="stylesheet" href="http://diogo-cruz.github.io//css/dark.css">
+    <link rel="stylesheet" type="text/css" href="https://diogo-cruz.github.io//css/normalize.min.css" media="print" onload="this.media='all'">
+    <link rel="stylesheet" type="text/css" href="https://diogo-cruz.github.io//css/main.css">
+    <link disabled id="dark-theme" rel="stylesheet" href="https://diogo-cruz.github.io//css/dark.css">
 
-    <script src="http://diogo-cruz.github.io//js/svg-injector.min.js"></script>
-    <script src="http://diogo-cruz.github.io//js/feather-icons.min.js"></script>
-    <script src="http://diogo-cruz.github.io//js/main.js"></script>
+    <script src="https://diogo-cruz.github.io//js/svg-injector.min.js"></script>
+    <script src="https://diogo-cruz.github.io//js/feather-icons.min.js"></script>
+    <script src="https://diogo-cruz.github.io//js/main.js"></script>
 
     
     

--- a/posts/first_post/index.html
+++ b/posts/first_post/index.html
@@ -38,13 +38,13 @@
     
     <link rel="canonical" href="http://diogo-cruz.github.io/posts/first_post/" />
 
-    <link rel="stylesheet" type="text/css" href="http://diogo-cruz.github.io//css/normalize.min.css" media="print" onload="this.media='all'">
-    <link rel="stylesheet" type="text/css" href="http://diogo-cruz.github.io//css/main.css">
-    <link disabled id="dark-theme" rel="stylesheet" href="http://diogo-cruz.github.io//css/dark.css">
+    <link rel="stylesheet" type="text/css" href="https://diogo-cruz.github.io//css/normalize.min.css" media="print" onload="this.media='all'">
+    <link rel="stylesheet" type="text/css" href="https://diogo-cruz.github.io//css/main.css">
+    <link disabled id="dark-theme" rel="stylesheet" href="https://diogo-cruz.github.io//css/dark.css">
 
-    <script src="http://diogo-cruz.github.io//js/svg-injector.min.js"></script>
-    <script src="http://diogo-cruz.github.io//js/feather-icons.min.js"></script>
-    <script src="http://diogo-cruz.github.io//js/main.js"></script>
+    <script src="https://diogo-cruz.github.io//js/svg-injector.min.js"></script>
+    <script src="https://diogo-cruz.github.io//js/feather-icons.min.js"></script>
+    <script src="https://diogo-cruz.github.io//js/main.js"></script>
 
     
     

--- a/posts/index.html
+++ b/posts/index.html
@@ -38,13 +38,13 @@
     
     <link rel="canonical" href="http://diogo-cruz.github.io/posts/" />
 
-    <link rel="stylesheet" type="text/css" href="http://diogo-cruz.github.io//css/normalize.min.css" media="print" onload="this.media='all'">
-    <link rel="stylesheet" type="text/css" href="http://diogo-cruz.github.io//css/main.css">
-    <link disabled id="dark-theme" rel="stylesheet" href="http://diogo-cruz.github.io//css/dark.css">
+    <link rel="stylesheet" type="text/css" href="https://diogo-cruz.github.io//css/normalize.min.css" media="print" onload="this.media='all'">
+    <link rel="stylesheet" type="text/css" href="https://diogo-cruz.github.io//css/main.css">
+    <link disabled id="dark-theme" rel="stylesheet" href="https://diogo-cruz.github.io//css/dark.css">
 
-    <script src="http://diogo-cruz.github.io//js/svg-injector.min.js"></script>
-    <script src="http://diogo-cruz.github.io//js/feather-icons.min.js"></script>
-    <script src="http://diogo-cruz.github.io//js/main.js"></script>
+    <script src="https://diogo-cruz.github.io//js/svg-injector.min.js"></script>
+    <script src="https://diogo-cruz.github.io//js/feather-icons.min.js"></script>
+    <script src="https://diogo-cruz.github.io//js/main.js"></script>
 
     
     

--- a/posts/mypost/index.html
+++ b/posts/mypost/index.html
@@ -38,13 +38,13 @@
     
     <link rel="canonical" href="http://diogo-cruz.github.io/posts/mypost/" />
 
-    <link rel="stylesheet" type="text/css" href="http://diogo-cruz.github.io//css/normalize.min.css" media="print" onload="this.media='all'">
-    <link rel="stylesheet" type="text/css" href="http://diogo-cruz.github.io//css/main.css">
-    <link disabled id="dark-theme" rel="stylesheet" href="http://diogo-cruz.github.io//css/dark.css">
+    <link rel="stylesheet" type="text/css" href="https://diogo-cruz.github.io//css/normalize.min.css" media="print" onload="this.media='all'">
+    <link rel="stylesheet" type="text/css" href="https://diogo-cruz.github.io//css/main.css">
+    <link disabled id="dark-theme" rel="stylesheet" href="https://diogo-cruz.github.io//css/dark.css">
 
-    <script src="http://diogo-cruz.github.io//js/svg-injector.min.js"></script>
-    <script src="http://diogo-cruz.github.io//js/feather-icons.min.js"></script>
-    <script src="http://diogo-cruz.github.io//js/main.js"></script>
+    <script src="https://diogo-cruz.github.io//js/svg-injector.min.js"></script>
+    <script src="https://diogo-cruz.github.io//js/feather-icons.min.js"></script>
+    <script src="https://diogo-cruz.github.io//js/main.js"></script>
 
     
     

--- a/tags/blog/index.html
+++ b/tags/blog/index.html
@@ -38,13 +38,13 @@
     
     <link rel="canonical" href="http://diogo-cruz.github.io/tags/blog/" />
 
-    <link rel="stylesheet" type="text/css" href="http://diogo-cruz.github.io//css/normalize.min.css" media="print" onload="this.media='all'">
-    <link rel="stylesheet" type="text/css" href="http://diogo-cruz.github.io//css/main.css">
-    <link disabled id="dark-theme" rel="stylesheet" href="http://diogo-cruz.github.io//css/dark.css">
+    <link rel="stylesheet" type="text/css" href="https://diogo-cruz.github.io//css/normalize.min.css" media="print" onload="this.media='all'">
+    <link rel="stylesheet" type="text/css" href="https://diogo-cruz.github.io//css/main.css">
+    <link disabled id="dark-theme" rel="stylesheet" href="https://diogo-cruz.github.io//css/dark.css">
 
-    <script src="http://diogo-cruz.github.io//js/svg-injector.min.js"></script>
-    <script src="http://diogo-cruz.github.io//js/feather-icons.min.js"></script>
-    <script src="http://diogo-cruz.github.io//js/main.js"></script>
+    <script src="https://diogo-cruz.github.io//js/svg-injector.min.js"></script>
+    <script src="https://diogo-cruz.github.io//js/feather-icons.min.js"></script>
+    <script src="https://diogo-cruz.github.io//js/main.js"></script>
 
     
     

--- a/tags/index.html
+++ b/tags/index.html
@@ -38,13 +38,13 @@
     
     <link rel="canonical" href="http://diogo-cruz.github.io/tags/" />
 
-    <link rel="stylesheet" type="text/css" href="http://diogo-cruz.github.io//css/normalize.min.css" media="print" onload="this.media='all'">
-    <link rel="stylesheet" type="text/css" href="http://diogo-cruz.github.io//css/main.css">
-    <link disabled id="dark-theme" rel="stylesheet" href="http://diogo-cruz.github.io//css/dark.css">
+    <link rel="stylesheet" type="text/css" href="https://diogo-cruz.github.io//css/normalize.min.css" media="print" onload="this.media='all'">
+    <link rel="stylesheet" type="text/css" href="https://diogo-cruz.github.io//css/main.css">
+    <link disabled id="dark-theme" rel="stylesheet" href="https://diogo-cruz.github.io//css/dark.css">
 
-    <script src="http://diogo-cruz.github.io//js/svg-injector.min.js"></script>
-    <script src="http://diogo-cruz.github.io//js/feather-icons.min.js"></script>
-    <script src="http://diogo-cruz.github.io//js/main.js"></script>
+    <script src="https://diogo-cruz.github.io//js/svg-injector.min.js"></script>
+    <script src="https://diogo-cruz.github.io//js/feather-icons.min.js"></script>
+    <script src="https://diogo-cruz.github.io//js/main.js"></script>
 
     
     


### PR DESCRIPTION
Was looking through the SPAR projects for this upcoming round and noticed your website was broken. Thought I would let you know so applicants can know what you are all about :)

Currently the build of the website cannot fetch css and js files for many browsers (Chrome, Firefox, probably more) because the requests for these resources are using the HTTP while the domain itself is HTTPS. This results in the webpage being unusable--looks like this when loaded:

<img width="500" alt="Screenshot 2024-12-18 at 12 35 18 PM" src="https://github.com/user-attachments/assets/055fc098-32ed-4f50-955f-f699c65457c8" />

Errors in the browser console include:


<img width="395" alt="Screenshot 2024-12-18 at 12 14 11 PM" src="https://github.com/user-attachments/assets/7795aae0-091a-41bc-8138-bfac064abc49" />

<img width="586" alt="Screenshot 2024-12-18 at 12 32 50 PM" src="https://github.com/user-attachments/assets/618b5d4c-6c9c-43aa-a40b-a9881a2baa54" />

I have fixed this by updating these resources to HTTPS. I suspect that because this problem does not happen when running the code locally, it hasn't been noticed. Updating these links should fix most issues with the current website when fetched over the web (I tested this using Chrome's local overrides tool). 